### PR TITLE
Fix analyzer race that dropped events and produced wrong progress

### DIFF
--- a/backend/pkg/analyzer/analyzer.go
+++ b/backend/pkg/analyzer/analyzer.go
@@ -6,31 +6,33 @@ import (
 	"forrest/backend/pkg/models"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Analyzer coordinates dependency analysis
+// Analyzer coordinates dependency analysis.
 type Analyzer struct {
 	workerPool *WorkerPool
 }
 
-// NewAnalyzer creates a new analyzer
+// NewAnalyzer creates a new analyzer.
 func NewAnalyzer(workerPool *WorkerPool) *Analyzer {
 	return &Analyzer{workerPool: workerPool}
 }
 
-// Analyze performs dependency analysis and streams events
+// Analyze performs dependency analysis and streams events on the
+// returned channel. The channel is closed when analysis finishes or
+// when the supplied context is cancelled.
 func (a *Analyzer) Analyze(ctx context.Context, req models.AnalyzeRequest) <-chan models.Event {
-	events := make(chan models.Event, 100)
+	events := make(chan models.Event, 256)
 
 	go func() {
 		defer close(events)
 
-		log.Printf("[ANALYZER] Starting analysis for package: %s", req.PackageJSON.Name)
+		log.Printf("[ANALYZER] Starting analysis for %s", req.PackageJSON.Name)
 		startTime := time.Now()
-		totalProcessed := 0
+		var totalProcessed int64
 
-		// Prepare root dependencies
 		rootDeps := make(map[string]string)
 		for k, v := range req.PackageJSON.Dependencies {
 			rootDeps[k] = v
@@ -41,24 +43,28 @@ func (a *Analyzer) Analyze(ctx context.Context, req models.AnalyzeRequest) <-cha
 			}
 		}
 
-		log.Printf("[ANALYZER] Root dependencies: %d (includeDevDeps: %v)", len(rootDeps), req.IncludeDevDependencies)
+		log.Printf("[ANALYZER] Root deps: %d (includeDevDeps=%v)", len(rootDeps), req.IncludeDevDependencies)
 
-		// Track dependencies by level
-		levelDeps := make(map[int]map[string]string)
-		levelDeps[1] = rootDeps
+		// Track packages we've already enqueued across all levels so we
+		// never fetch the same package twice (avoids work and
+		// duplicate node events).
+		seen := make(map[string]struct{})
+		for name := range rootDeps {
+			seen[name] = struct{}{}
+		}
 
-		// Process each level
+		levelDeps := map[int]map[string]string{1: rootDeps}
+
 		for level := 1; level <= req.MaxDepth; level++ {
 			deps := levelDeps[level]
 			if len(deps) == 0 {
-				log.Printf("[ANALYZER] Level %d: No dependencies to process, stopping", level)
+				log.Printf("[ANALYZER] Level %d: nothing to process, stopping", level)
 				break
 			}
 
-			log.Printf("[ANALYZER] Level %d: Processing %d dependencies", level, len(deps))
+			log.Printf("[ANALYZER] Level %d: processing %d deps", level, len(deps))
 
-			// Send initial progress
-			events <- models.Event{
+			if !sendEvent(ctx, events, models.Event{
 				Type: models.EventTypeProgress,
 				Data: models.ProgressData{
 					Current:        0,
@@ -66,105 +72,130 @@ func (a *Analyzer) Analyze(ctx context.Context, req models.AnalyzeRequest) <-cha
 					Level:          level,
 					CurrentPackage: fmt.Sprintf("Loading level %d dependencies...", level),
 				},
+			}) {
+				return
 			}
 
-			// Process dependencies in parallel
 			nextLevelDeps := make(map[string]string)
-			var mu sync.Mutex
+			var nextMu sync.Mutex
+			var completed int64
 			var wg sync.WaitGroup
 
-			current := 0
 			for depName, depVersion := range deps {
-				wg.Add(1)
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 
-				go func(name, version string, idx int) {
+				wg.Add(1)
+				go func(name, version string) {
 					defer wg.Done()
 
-					log.Printf("[ANALYZER] Level %d: Fetching %s@%s", level, name, version)
-
-					// Fetch package
 					node, err := a.workerPool.FetchPackage(ctx, name, version)
 					if err != nil {
-						log.Printf("[ANALYZER] Level %d: ERROR fetching %s@%s: %v", level, name, version, err)
-						events <- models.Event{
+						if ctx.Err() != nil {
+							return
+						}
+						log.Printf("[ANALYZER] Level %d: error fetching %s@%s: %v", level, name, version, err)
+						sendEvent(ctx, events, models.Event{
 							Type: models.EventTypeError,
 							Data: models.ErrorData{
 								Package: name,
 								Error:   err.Error(),
 							},
-						}
+						})
+						// Still count as completed for progress purposes
+						c := atomic.AddInt64(&completed, 1)
+						sendEvent(ctx, events, models.Event{
+							Type: models.EventTypeProgress,
+							Data: models.ProgressData{
+								Current:        int(c),
+								Total:          len(deps),
+								Level:          level,
+								CurrentPackage: name,
+							},
+						})
 						return
 					}
 
-					log.Printf("[ANALYZER] Level %d: Successfully fetched %s@%s (deps: %d, devDeps: %d)",
-						level, name, node.Version, len(node.Dependencies), len(node.DevDependencies))
+					atomic.AddInt64(&totalProcessed, 1)
 
-					totalProcessed++
-
-					// Send node event
-					events <- models.Event{
+					if !sendEvent(ctx, events, models.Event{
 						Type:  models.EventTypeNode,
 						Data:  node,
 						Level: level,
+					}) {
+						return
 					}
 
-					// Send progress update
-					mu.Lock()
-					events <- models.Event{
+					c := atomic.AddInt64(&completed, 1)
+					if !sendEvent(ctx, events, models.Event{
 						Type: models.EventTypeProgress,
 						Data: models.ProgressData{
-							Current:        idx + 1,
+							Current:        int(c),
 							Total:          len(deps),
 							Level:          level,
 							CurrentPackage: name,
 						},
+					}) {
+						return
 					}
-					mu.Unlock()
 
-					// Collect next level dependencies
 					if level < req.MaxDepth {
-						mu.Lock()
+						nextMu.Lock()
 						for nextName, nextVer := range node.Dependencies {
-							if _, exists := nextLevelDeps[nextName]; !exists {
-								// Avoid duplicates and circular deps
+							if _, ok := seen[nextName]; !ok {
+								seen[nextName] = struct{}{}
 								nextLevelDeps[nextName] = nextVer
 							}
 						}
 						if req.IncludeDevDependencies {
 							for nextName, nextVer := range node.DevDependencies {
-								if _, exists := nextLevelDeps[nextName]; !exists {
+								if _, ok := seen[nextName]; !ok {
+									seen[nextName] = struct{}{}
 									nextLevelDeps[nextName] = nextVer
 								}
 							}
 						}
-						mu.Unlock()
+						nextMu.Unlock()
 					}
-				}(depName, depVersion, current)
-
-				current++
+				}(depName, depVersion)
 			}
 
 			wg.Wait()
-			log.Printf("[ANALYZER] Level %d: Completed - processed %d packages", level, len(deps))
 
-			// Store next level deps
+			if ctx.Err() != nil {
+				return
+			}
+
+			log.Printf("[ANALYZER] Level %d: done, found %d deps for next level", level, len(nextLevelDeps))
 			if len(nextLevelDeps) > 0 {
-				log.Printf("[ANALYZER] Level %d: Found %d dependencies for next level", level, len(nextLevelDeps))
 				levelDeps[level+1] = nextLevelDeps
 			}
 		}
 
-		// Send complete event
 		duration := time.Since(startTime)
-		log.Printf("[ANALYZER] Analysis complete - Total processed: %d, Duration: %s", totalProcessed, duration)
-		events <- models.Event{
+		log.Printf("[ANALYZER] Done: processed=%d duration=%s", atomic.LoadInt64(&totalProcessed), duration)
+		sendEvent(ctx, events, models.Event{
 			Type: models.EventTypeComplete,
 			Data: models.CompleteData{
-				TotalProcessed: totalProcessed,
+				TotalProcessed: int(atomic.LoadInt64(&totalProcessed)),
 				Duration:       duration.String(),
 			},
-		}
+		})
 	}()
 
 	return events
+}
+
+// sendEvent sends an event respecting context cancellation. Returns
+// false if the context was cancelled before the event could be sent.
+func sendEvent(ctx context.Context, events chan<- models.Event, event models.Event) bool {
+	select {
+	case events <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }

--- a/backend/pkg/handler/analyze.go
+++ b/backend/pkg/handler/analyze.go
@@ -1,95 +1,55 @@
 package handler
 
 import (
-	"context"
 	"fmt"
-	"forrest/backend/pkg/analyzer"
 	"forrest/backend/pkg/models"
 	"forrest/backend/pkg/sse"
 	"log"
-	"time"
 
 	"github.com/gofiber/fiber/v2"
 )
 
-// AnalyzeHandler handles analysis requests
+// AnalyzeHandler accepts analyze requests and stores them in a session
+// to be consumed by the SSE handler when the client connects.
 type AnalyzeHandler struct {
-	analyzer   *analyzer.Analyzer
 	sseManager *sse.Manager
 }
 
-// NewAnalyzeHandler creates a new analyze handler
-func NewAnalyzeHandler(analyzer *analyzer.Analyzer, sseManager *sse.Manager) *AnalyzeHandler {
-	return &AnalyzeHandler{
-		analyzer:   analyzer,
-		sseManager: sseManager,
-	}
+// NewAnalyzeHandler creates a new analyze handler.
+func NewAnalyzeHandler(sseManager *sse.Manager) *AnalyzeHandler {
+	return &AnalyzeHandler{sseManager: sseManager}
 }
 
-// Analyze handles POST /api/analyze
+// Analyze handles POST /api/analyze. It does not start the analysis —
+// the SSE handler does, when the client connects — so events cannot be
+// dropped due to a race between POST returning and the EventSource
+// being opened.
 func (h *AnalyzeHandler) Analyze(c *fiber.Ctx) error {
-	log.Println("=== [ANALYZE] Received analyze request ===")
-
 	var req models.AnalyzeRequest
 	if err := c.BodyParser(&req); err != nil {
-		log.Printf("[ANALYZE] ERROR: Failed to parse request body: %v", err)
+		log.Printf("[ANALYZE] Failed to parse request body: %v", err)
 		return c.Status(400).JSON(fiber.Map{
 			"error": "Invalid request body",
 		})
 	}
 
-	log.Printf("[ANALYZE] Request parsed - Package: %s, MaxDepth: %d, IncludeDevDeps: %v, ParallelWorkers: %d",
-		req.PackageJSON.Name, req.MaxDepth, req.IncludeDevDependencies, req.ParallelWorkers)
-
-	// Validate
 	if req.PackageJSON.Name == "" {
-		log.Println("[ANALYZE] ERROR: Package name is missing")
 		return c.Status(400).JSON(fiber.Map{
 			"error": "Package name is required",
 		})
 	}
 
-	// Set defaults
 	if req.MaxDepth == 0 {
 		req.MaxDepth = 2
-		log.Printf("[ANALYZE] Set default MaxDepth: %d", req.MaxDepth)
 	}
 	if req.ParallelWorkers == 0 {
 		req.ParallelWorkers = 100
-		log.Printf("[ANALYZE] Set default ParallelWorkers: %d", req.ParallelWorkers)
 	}
 
-	// Create session
-	sessionID := h.sseManager.CreateSession()
-	log.Printf("[ANALYZE] Created session ID: %s", sessionID)
+	sessionID := h.sseManager.CreateSession(req)
+	log.Printf("[ANALYZE] Created session %s for %s (depth=%d, dev=%v)",
+		sessionID, req.PackageJSON.Name, req.MaxDepth, req.IncludeDevDependencies)
 
-	// Start analysis in background
-	go func() {
-		log.Printf("[ANALYZE:%s] Starting background analysis", sessionID)
-		startTime := time.Now()
-		ctx := context.Background()
-		events := h.analyzer.Analyze(ctx, req)
-
-		eventCount := 0
-		for event := range events {
-			eventCount++
-			log.Printf("[ANALYZE:%s] Sending event #%d - Type: %s", sessionID, eventCount, event.Type)
-			h.sseManager.SendEvent(sessionID, event)
-		}
-
-		duration := time.Since(startTime)
-		log.Printf("[ANALYZE:%s] Analysis complete - Total events: %d, Duration: %s",
-			sessionID, eventCount, duration)
-
-		// Close session after completion (with delay)
-		time.AfterFunc(10*time.Second, func() {
-			log.Printf("[ANALYZE:%s] Closing session", sessionID)
-			h.sseManager.CloseSession(sessionID)
-		})
-	}()
-
-	// Return session info
-	log.Printf("[ANALYZE] Returning session info to client - SessionID: %s", sessionID)
 	return c.Status(202).JSON(models.AnalyzeResponse{
 		SessionID: sessionID,
 		StreamURL: fmt.Sprintf("/api/events/%s", sessionID),

--- a/backend/pkg/handler/sse.go
+++ b/backend/pkg/handler/sse.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"bufio"
+	"context"
+	"forrest/backend/pkg/analyzer"
 	"forrest/backend/pkg/models"
 	"forrest/backend/pkg/sse"
 	"log"
@@ -9,33 +11,35 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// SSEHandler handles SSE streaming
+// SSEHandler streams analysis events to the client. The analyzer is
+// started inside this handler when the client connects, so events
+// cannot accumulate without a reader.
 type SSEHandler struct {
 	sseManager *sse.Manager
+	analyzer   *analyzer.Analyzer
 }
 
-// NewSSEHandler creates a new SSE handler
-func NewSSEHandler(sseManager *sse.Manager) *SSEHandler {
-	return &SSEHandler{sseManager: sseManager}
+// NewSSEHandler creates a new SSE handler.
+func NewSSEHandler(sseManager *sse.Manager, a *analyzer.Analyzer) *SSEHandler {
+	return &SSEHandler{
+		sseManager: sseManager,
+		analyzer:   a,
+	}
 }
 
-// Stream handles GET /api/events/:sessionId
+// Stream handles GET /api/events/:sessionId.
 func (h *SSEHandler) Stream(c *fiber.Ctx) error {
 	sessionID := c.Params("sessionId")
 	log.Printf("[SSE] Client connecting to session: %s", sessionID)
 
-	// Get session
-	eventChan, exists := h.sseManager.GetSession(sessionID)
-	if !exists {
-		log.Printf("[SSE] ERROR: Session not found: %s", sessionID)
+	req, ok := h.sseManager.ConsumeSession(sessionID)
+	if !ok {
+		log.Printf("[SSE] Session not found or expired: %s", sessionID)
 		return c.Status(404).JSON(fiber.Map{
 			"error": "Session not found",
 		})
 	}
 
-	log.Printf("[SSE:%s] Session found, setting up SSE stream", sessionID)
-
-	// Set SSE headers
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
@@ -43,28 +47,41 @@ func (h *SSEHandler) Stream(c *fiber.Ctx) error {
 	c.Set("X-Accel-Buffering", "no")
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		// Send initial connection event
-		log.Printf("[SSE:%s] Sending connection event", sessionID)
-		w.WriteString("event: connected\ndata: {\"status\":\"connected\"}\n\n")
-		w.Flush()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		events := h.analyzer.Analyze(ctx, req)
+
+		if _, err := w.WriteString("event: connected\ndata: {\"status\":\"connected\"}\n\n"); err != nil {
+			log.Printf("[SSE:%s] Write error on connect event: %v", sessionID, err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			log.Printf("[SSE:%s] Flush error on connect event (client likely disconnected): %v", sessionID, err)
+			return
+		}
 
 		eventsSent := 0
-		// Stream events
-		for event := range eventChan {
+		for event := range events {
 			eventsSent++
-			log.Printf("[SSE:%s] Streaming event #%d - Type: %s", sessionID, eventsSent, event.Type)
 			formatted := sse.FormatSSE(event)
-			w.WriteString(formatted)
-			w.Flush()
 
-			// Exit on complete
+			if _, err := w.WriteString(formatted); err != nil {
+				log.Printf("[SSE:%s] Write error after %d events: %v", sessionID, eventsSent, err)
+				return
+			}
+			if err := w.Flush(); err != nil {
+				log.Printf("[SSE:%s] Flush error after %d events (client disconnected): %v", sessionID, eventsSent, err)
+				return
+			}
+
 			if event.Type == models.EventTypeComplete {
-				log.Printf("[SSE:%s] Complete event sent, closing stream - Total events: %d", sessionID, eventsSent)
-				break
+				log.Printf("[SSE:%s] Complete event sent, total events: %d", sessionID, eventsSent)
+				return
 			}
 		}
 
-		log.Printf("[SSE:%s] Stream closed", sessionID)
+		log.Printf("[SSE:%s] Events channel closed without complete event, total events: %d", sessionID, eventsSent)
 	})
 
 	return nil

--- a/backend/pkg/sse/manager.go
+++ b/backend/pkg/sse/manager.go
@@ -3,68 +3,82 @@ package sse
 import (
 	"forrest/backend/pkg/models"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
 
-// Manager handles SSE session management
+// sessionTTL is how long a pending session is kept before it expires
+// if the SSE client never connects.
+const sessionTTL = 60 * time.Second
+
+type pendingSession struct {
+	request   models.AnalyzeRequest
+	createdAt time.Time
+}
+
+// Manager stores pending analyze requests keyed by session ID until the
+// SSE client connects and consumes them.
 type Manager struct {
-	sessions map[string]chan models.Event
-	mu       sync.RWMutex
+	sessions map[string]*pendingSession
+	mu       sync.Mutex
 }
 
-// NewManager creates a new SSE manager
+// NewManager creates a new session manager and starts the background
+// cleanup goroutine.
 func NewManager() *Manager {
-	return &Manager{
-		sessions: make(map[string]chan models.Event),
+	m := &Manager{
+		sessions: make(map[string]*pendingSession),
 	}
+	go m.cleanupLoop()
+	return m
 }
 
-// CreateSession creates a new SSE session
-func (m *Manager) CreateSession() string {
+// CreateSession stores the request and returns a new session ID.
+func (m *Manager) CreateSession(req models.AnalyzeRequest) string {
 	sessionID := uuid.New().String()
 
 	m.mu.Lock()
-	m.sessions[sessionID] = make(chan models.Event, 100)
+	m.sessions[sessionID] = &pendingSession{
+		request:   req,
+		createdAt: time.Now(),
+	}
 	m.mu.Unlock()
 
 	return sessionID
 }
 
-// GetSession retrieves a session channel
-func (m *Manager) GetSession(sessionID string) (chan models.Event, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	ch, exists := m.sessions[sessionID]
-	return ch, exists
-}
-
-// CloseSession closes and removes a session
-func (m *Manager) CloseSession(sessionID string) {
+// ConsumeSession atomically retrieves and removes a session. Returns
+// false if the session does not exist or has expired.
+func (m *Manager) ConsumeSession(sessionID string) (models.AnalyzeRequest, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if ch, exists := m.sessions[sessionID]; exists {
-		close(ch)
-		delete(m.sessions, sessionID)
+	s, exists := m.sessions[sessionID]
+	if !exists {
+		return models.AnalyzeRequest{}, false
 	}
+	delete(m.sessions, sessionID)
+
+	if time.Since(s.createdAt) > sessionTTL {
+		return models.AnalyzeRequest{}, false
+	}
+
+	return s.request, true
 }
 
-// SendEvent sends an event to a session
-func (m *Manager) SendEvent(sessionID string, event models.Event) bool {
-	m.mu.RLock()
-	ch, exists := m.sessions[sessionID]
-	m.mu.RUnlock()
+func (m *Manager) cleanupLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
 
-	if !exists {
-		return false
-	}
-
-	select {
-	case ch <- event:
-		return true
-	default:
-		return false
+	for range ticker.C {
+		m.mu.Lock()
+		now := time.Now()
+		for id, s := range m.sessions {
+			if now.Sub(s.createdAt) > sessionTTL {
+				delete(m.sessions, id)
+			}
+		}
+		m.mu.Unlock()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ func main() {
 	sseManager := sse.NewManager()
 
 	// Initialize handlers
-	analyzeHandler := handler.NewAnalyzeHandler(analyzerService, sseManager)
-	sseHandler := handler.NewSSEHandler(sseManager)
+	analyzeHandler := handler.NewAnalyzeHandler(sseManager)
+	sseHandler := handler.NewSSEHandler(sseManager, analyzerService)
 
 	// Create Fiber app
 	app := fiber.New(fiber.Config{


### PR DESCRIPTION
## Summary
- Move analyzer startup from `POST /api/analyze` into the SSE handler so events are never produced without a reader. POST now just stashes the request in the session manager and returns the session ID; the analyzer runs inside the SSE stream, writing directly to the response.
- Fix progress counter going backwards by tracking actual completion order with `atomic.AddInt64` instead of the goroutine's iteration index.
- Fix data race on `totalProcessed` (plain `++` from many goroutines) by switching to atomic.
- Deduplicate packages across levels with a `seen` set so the same package isn't fetched twice.
- Respect `ctx.Done()` on every channel send, so a client disconnect tears the analyzer down cleanly.

## Why
The original flow had a race between `POST /api/analyze` returning the session ID and the browser opening the `EventSource`. Events flowed into a 100-buffer session channel via a non-blocking `SendEvent` that silently dropped on overflow. For small trees, the analyzer would usually finish before the SSE client even connected, and 10 s later the session was deleted — the subsequent GET got `Session not found` (404). For larger trees, the channel would overflow mid-stream and the UI never saw the missing packages. Progress also reported the iteration index, so with concurrent fetches the bar jumped backwards (e.g. `1, 2, 0, 2, 3, 1`).

## Reviewer notes
- New session lifecycle: sessions are single-use. Reconnecting to a consumed session intentionally returns 404. Pending sessions expire after 60 s only if no client ever connects.
- `SSEHandler` now depends on `*analyzer.Analyzer`; `main.go` wiring was updated accordingly. `AnalyzeHandler` no longer takes the analyzer.
- Disconnect detection relies on `bufio.Writer.Flush` returning an error when the client goes away; that triggers `cancel()` and the in-flight goroutines exit on their next `ctx.Done()` check or HTTP cancellation.

## Test plan
- [x] `go build ./...` clean
- [x] Small tree (lodash + axios, depth 2): SSE connected 5 s after POST still receives every event from `connected` through `complete`.
- [x] Larger tree (8 root packages, depth 2): 76 node events + 80 progress events + 1 complete, progress monotonic 1..N at each level.
- [x] Reconnect to a consumed session returns 404 with `{"error":"Session not found"}`.
- [x] Unknown session ID returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)